### PR TITLE
Stop php error when saving from the Pagebuilder options page

### DIFF
--- a/inc/class-wds-page-builder-options.php
+++ b/inc/class-wds-page-builder-options.php
@@ -168,6 +168,9 @@ class WDS_Page_Builder_Options {
 	 */
 	public function prevent_blank_templates( $new_value, $old_value ) {
 		$saved_layouts = $new_value['parts_saved_layouts'];
+		if( empty( $saved_layouts ) ) {
+			return $new_value;
+		}
 		$i = 0;
 		foreach ( $saved_layouts as $layout ) {
 			$layout['template_group'] = array_diff( $layout['template_group'], array( 'none' ) );


### PR DESCRIPTION
When saving from the PB options page a php error was being thrown because
the parts_saved_layouts field was null. This caused the foreach to fail
as it had nothing to iterate over.

May be related to #39 
