### PR TITLE
Switch to collapsed parts by default

### DIFF
--- a/inc/class-wds-page-builder-layouts.php
+++ b/inc/class-wds-page-builder-layouts.php
@@ -85,6 +85,7 @@ if ( ! class_exists( 'WDS_Page_Builder_Layouts' ) ) {
 					'add_button'    => __( 'Add another template part', 'wds-simple-page-builder' ),
 					'remove_button' => __( 'Remove template part', 'wds-simple-page-builder' ),
 					'sortable'      => true,
+					'closed'		=> true,
 				)
 			) );
 


### PR DESCRIPTION
The parts in a saved layout will collapsed initially when the saved
layout is opened for editing. Fixes #18
